### PR TITLE
Add publish dry run workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,6 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     container: rust:1.52.1
-    environment: crates-publish
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Publish
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  dry-run:
+    runs-on: "ubuntu-latest"
+    container: rust:1.52.1
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Publish Dry Run
+        run: cargo publish --dry-run

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,6 @@
 name: Publish
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,6 @@ jobs:
         run: cargo test
 
   dry-run:
-    needs: test
     runs-on: ubuntu-latest
     container: rust:1.52.1
 
@@ -35,7 +34,7 @@ jobs:
         run: cargo publish --dry-run
 
   publish:
-    needs: dry-run
+    needs: [test, dry-run]
     runs-on: ubuntu-latest
     container: rust:1.52.1
     environment: crates-publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,8 +8,24 @@ on:
   workflow_dispatch:
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    container: rust:1.52.1
+    services:
+      consul:
+        image: consul:1.9.3
+    env:
+      CONSUL_HTTP_ADDR: http://consul:8500
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Test
+        run: cargo test
+
   dry-run:
-    runs-on: "ubuntu-latest"
+    needs: test
+    runs-on: ubuntu-latest
     container: rust:1.52.1
     environment: crates-publish
 
@@ -18,3 +34,15 @@ jobs:
 
       - name: Publish Dry Run
         run: cargo publish --dry-run
+
+  publish:
+    needs: dry-run
+    runs-on: ubuntu-latest
+    container: rust:1.52.1
+    environment: crates-publish
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Publish to Crates.io
+        run: cargo publish --token ${{ secrets.CARGO_PUBLISH_TOKEN_SFONG }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ jobs:
   dry-run:
     runs-on: "ubuntu-latest"
     container: rust:1.52.1
+    environment: crates-publish
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
# What problem are we solving?
Manual publishing of crate
# How are we solving the problem?
Creating a workflow for it

# Crates Token
- Stored in [`crates-publish`](https://github.com/Roblox/rs-consul/settings/environments/262786950/edit) environment secret
- As `CARGO_PUBLISH_TOKEN_SFONG`
- You can read more about `environments` here: https://docs.github.com/en/actions/reference/environments

# Running the workflow
- We can run the workflow via manual dispatch
- It will need to be approved by at least one of
![image](https://user-images.githubusercontent.com/77701536/124663677-3f49e980-de5f-11eb-8f73-d9f643ec51ae.png)
- You can find ones that need approval here: https://github.com/Roblox/rs-consul/actions/workflows/publish.yml

# Example Run
Added an exception in the Environment to use to allow this branch, but restricted it back to  `main`
https://github.com/Roblox/rs-consul/actions/runs/1005648409

# TODO
- Get @kushudai to upload his own crates.io token to: https://github.com/Roblox/rs-consul/settings/environments/262786950/edit as `CARGO_PUBLISH_TOKEN_KUSHUDAI`
- Use that secret in the workflow
- Delete `CARGO_PUBLISH_TOKEN_SFONG ` one

# Checks
Please check these off before promoting the pull request to non-draft status.
- [x] All CI checks are green.
- [x] I have reviewed the proposed changes myself.
