### PR TITLE
ADHOC: Add cargo metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,11 @@ name = "rs-consul"
 version = "0.1.0"
 authors = ["Roblox"]
 edition = "2018"
+description = "This crate provides access to a set of strongly typed apis to interact with consul (https://www.consul.io/)"
+readme = "README.md"
+repository = "https://github.com/Roblox/rs-consul"
+license = "MIT"
+license-file = "LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
# What problem are we solving?
No metadata, required by crates.io
# How are we solving the problem?
Adding metadata

# Checks
Please check these off before promoting the pull request to non-draft status.
- [ ] All CI checks are green.
- [ ] I have reviewed the proposed changes myself.
