### PR TITLE
Add cool badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # rs-consul
+[![Crates.io: rs-consul](https://img.shields.io/crates/v/rs-consul.svg)](https://crates.io/crates/rs-consul)
+[![Documentation](https://docs.rs/rs-consul/badge.svg)](https://docs.rs/rs-consul)
 [![Main](https://github.com/Roblox/rs-consul/actions/workflows/main.yml/badge.svg)](https://github.com/Roblox/rs-consul/actions/workflows/main.yml)
 
 This crate provides access to a set of strongly typed apis to interact with


### PR DESCRIPTION
# What problem are we solving?
The README didn't link to docs + crates.io

# How are we solving the problem?
Add the cool badges.

# Checks
Please check these off before promoting the pull request to non-draft status.
- [x] All CI checks are green.
- [x] I have reviewed the proposed changes myself.
