### PR TITLE
Add List Services endpoint to consul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 ### Security
 
-## 0.1.2 - 2021-07-20
+## 1.0.0 - 2021-07-20
 ### Added
 - register_entity method and RegisterEntityPayload, and associated, structs
 - get_all_registered_service_names method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 ### Security
 
+## 0.1.2 - 2021-07-20
+### Added
+- register_entity method
+- get_all_registered_service_names method
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
 ## 0.1.0 - 2021-06-10
 ### Added
 - Initialized repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 ### Security
 
-## 1.0.0 - 2021-07-20
+## 0.2.0 - 2021-07-20
 ### Added
 - register_entity method and RegisterEntityPayload, and associated, structs
 - get_all_registered_service_names method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## 0.1.2 - 2021-07-20
 ### Added
-- register_entity method
+- register_entity method and RegisterEntityPayload, and associated, structs
 - get_all_registered_service_names method
+- introduced QueryOptions struct to encapsulate common query options
+- introduced ResponseMeta to encapsulate the index returned
 ### Changed
+- get_service_nodes and get_service_addresses_and_ports methods now take QueryOptions as a new parameter
+- get_service_nodes return a ReponseMeta
+- GetServiceNodesRequest was modified to remove redundant fields
 ### Deprecated
 ### Removed
 ### Fixed
+- clippy warnings for some tests
 ### Security
 
 ## 0.1.0 - 2021-06-10

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs-consul"
-version = "0.1.2"
+version = "1.0.0"
 authors = ["Roblox"]
 edition = "2018"
 description = "This crate provides access to a set of strongly typed apis to interact with consul (https://www.consul.io/)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs-consul"
-version = "1.0.0"
+version = "0.2.0"
 authors = ["Roblox"]
 edition = "2018"
 description = "This crate provides access to a set of strongly typed apis to interact with consul (https://www.consul.io/)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs-consul"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Roblox"]
 edition = "2018"
 description = "This crate provides access to a set of strongly typed apis to interact with consul (https://www.consul.io/)"

--- a/src/types.rs
+++ b/src/types.rs
@@ -30,7 +30,7 @@ use smart_default::SmartDefault;
 
 // TODO retrofit other get APIs to use this struct
 /// Query options for Consul endpoints.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct QueryOptions {
     /// Specifies the namespace to use.
     /// If not provided, the namespace will be inferred from the request's ACL token, or will default to the default namespace.
@@ -319,6 +319,7 @@ pub struct RegisterEntityPayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub SkipNodeUpdate: Option<bool>,
 }
+
 /// The service to register with consul's global catalog.
 /// See https://www.consul.io/api/agent/service for more information.
 #[allow(non_snake_case)]
@@ -345,6 +346,7 @@ pub struct RegisterEntityService {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub Namespace: Option<String>,
 }
+
 /// Information related to registering a check.
 /// See https://www.consul.io/docs/discovery/checks for more information.
 #[allow(non_snake_case)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -22,9 +22,53 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
 
+use std::collections::HashMap;
+use std::time::Duration;
+
 use serde::{self, Deserialize, Serialize, Serializer};
 use smart_default::SmartDefault;
-use std::time::Duration;
+
+// TODO retrofit other get APIs to use this struct
+/// Query options for Consul endpoints.
+#[derive(Debug)]
+pub struct QueryOptions {
+    /// Specifies the namespace to use.
+    /// If not provided, the namespace will be inferred from the request's ACL token, or will default to the default namespace.
+    /// This is specified as part of the URL as a query parameter. Added in Consul 1.7.0.
+    /// NOTE: usage of this query parameter requires Consul enterprise.
+    pub namespace: Option<String>,
+    /// Specifies the datacenter to query.
+    /// This will default to the datacenter of the agent being queried.
+    /// This is specified as part of the URL as a query parameter.
+    pub datacenter: Option<String>,
+    /// The timeout to apply to the query, if any, defaults to 5s.
+    pub timeout: Option<Duration>,
+    /// The index to supply as a query parameter, if the endpoint supports blocking queries.
+    pub index: Option<u64>,
+    /// The time to block for, when used in association with an index, if the endpoint supports blocking queries.
+    /// Server side default of 5 minute is applied if not specified, with a limit of 10 minutes and maximum granularity of seconds.
+    pub wait: Option<Duration>,
+}
+impl Default for QueryOptions {
+    fn default() -> Self {
+        Self {
+            namespace: None,
+            datacenter: None,
+            timeout: Some(Duration::from_secs(5)),
+            index: None,
+            wait: None,
+        }
+    }
+}
+
+/// Encapsulates a consul query response and the returned metadata, if any.
+#[derive(Debug)]
+pub struct ResponseMeta<T> {
+    /// Query response.
+    pub response: T,
+    /// The index returned from the consul query via the X-Consul-Index header.
+    pub index: u64,
+}
 
 /// Represents a request to delete a key or all keys sharing a prefix from Consul's Key Value store.
 #[derive(Clone, Debug, SmartDefault, Serialize, Deserialize, PartialEq)]
@@ -244,6 +288,91 @@ pub(crate) struct CreateSessionRequest {
     pub(crate) ttl: Duration,
 }
 
+/// Payload struct to register or update entries in consul's catalog.
+/// See https://www.consul.io/api-docs/catalog#register-entity for more information.
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RegisterEntityPayload {
+    /// Optional UUID to assign to the node. This string is required to be 36-characters and UUID formatted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ID: Option<String>,
+    /// Node ID to register.
+    pub Node: String,
+    /// The address to register.
+    pub Address: String,
+    /// The datacenter to register in, defaults to the agent's datacenter.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub Datacenter: Option<String>,
+    /// Tagged addressed to register with.
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub TaggedAddresses: HashMap<String, String>,
+    /// KV metadata paris to register with.
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub NodeMeta: HashMap<String, String>,
+    /// Optional service to register.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub Service: Option<RegisterEntityService>,
+    /// Optional check to register
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub Check: Option<RegisterEntityCheck>,
+    /// Whether to skip updating the nodes information in the registration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub SkipNodeUpdate: Option<bool>,
+}
+/// The service to register with consul's global catalog.
+/// See https://www.consul.io/api/agent/service for more information.
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RegisterEntityService {
+    /// ID to register service will, defaults to Service.Service property.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ID: Option<String>,
+    /// The name of the service.
+    pub Service: String,
+    /// Optional tags associated with the service.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub Tags: Vec<String>,
+    /// Optional map of explicit LAN and WAN addresses for the service.
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub TaggedAddresses: HashMap<String, String>,
+    /// Optional key value meta associated with the service.
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub Meta: HashMap<String, String>,
+    /// The port of the service
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub Port: Option<u16>,
+    /// The consul namespace to register the service in.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub Namespace: Option<String>,
+}
+/// Information related to registering a check.
+/// See https://www.consul.io/docs/discovery/checks for more information.
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RegisterEntityCheck {
+    /// The node to execute the check on.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub Node: Option<String>,
+    /// Optional check id, defaults to the name of the check.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub CheckID: Option<String>,
+    /// The name associated with the check
+    pub Name: String,
+    /// Opaque field encapsulating human-readable text.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub Notes: Option<String>,
+    /// The status of the check. Must be one of 'passing', 'warning', or 'critical'.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub Status: Option<String>,
+    /// ID of the service this check is for. If no ID of a service running on the node is provided,
+    /// the check is treated as a node level check
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ServiceID: Option<String>,
+    /// Details for a TCP or HTTP health check.
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub Definition: HashMap<String, String>,
+}
+
 /// Request for the nodes providing a specified service registered in Consul.
 #[derive(Clone, Debug, SmartDefault, Serialize, Deserialize, PartialEq)]
 pub struct GetServiceNodesRequest<'a> {
@@ -254,14 +383,6 @@ pub struct GetServiceNodesRequest<'a> {
     /// Note that using `near` will ignore `use_streaming_backend` and always use blocking queries, because the data required to
     /// sort the results is not available to the streaming backend.
     pub near: Option<&'a str>,
-    /// Specifies the namespace to use.
-    /// If not provided, the namespace will be inferred from the request's ACL token, or will default to the default namespace.
-    /// This is specified as part of the URL as a query parameter. Added in Consul 1.7.0.
-    pub namespace: Option<&'a str>,
-    /// Specifies the datacenter to query.
-    /// This will default to the datacenter of the agent being queried.
-    /// This is specified as part of the URL as a query parameter.
-    pub datacenter: Option<&'a str>,
     /// (bool: false) Specifies that the server should return only nodes with all checks in the passing state.
     /// This can be used to avoid additional filtering on the client side.
     pub passing: bool,


### PR DESCRIPTION
# What problem are we solving?
Expose a method to retrieve the name of all services registered in consul for a given datacenter.
# How are we solving the problem?
Retrieves the list of services via https://www.consul.io/api-docs/catalog#list-services.
NOTE: Future work can be done to accept a node-meta filter to reduce the amount of data that is returned over the wire.
- Add method to register an entity with consul.
- Add QueryOptions and ResponseMeta to encapsulate query and response metadata respectively. 
- Change get_service_nodes to take and return QueryOptions and ResponseMeta.

# Checks
Please check these off before promoting the pull request to non-draft status.
- [ ] All CI checks are green.
- [x] I have reviewed the proposed changes myself.
