### PR TITLE
Update GHA thrid party actions

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -24,6 +24,6 @@ jobs:
         run: cargo update
 
       - name: Commit the changes
-        uses: EndBug/add-and-commit@v7
+        uses: roblox-actionscache/EndBug-add-and-commit@v7
         with:
           author_name: GitHub Action Bot


### PR DESCRIPTION
This batch change updates serveral GHA third party actions to use roblox-actionscache.

[_Created by Sourcegraph batch change `tianqiliu/update-gha-third-party-actions`._](https://sourcegraph.rbx.com/users/tianqiliu/batch-changes/update-gha-third-party-actions)