### PR TITLE
Add support for Rustls

### DIFF
--- a/.github/workflows/rustls.yml
+++ b/.github/workflows/rustls.yml
@@ -1,0 +1,34 @@
+name: Rustls
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    container: rust:1.52.1
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build
+        run: cargo build --no-default-features --features rustls-native
+
+  test:
+    runs-on: "ubuntu-latest"
+    container: rust:1.52.1
+    services:
+      consul:
+        image: consul:1.9.3
+    env:
+      CONSUL_HTTP_ADDR: http://consul:8500
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Test
+        run: cargo test --no-default-features --features rustls-native

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ license = "MIT"
 license-file = "LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["default-tls"]
+default-tls  = ["hyper-tls"]
+rustls-native = ["hyper-rustls/rustls-native-certs"]
+rustls-webpki = ["hyper-rustls/webpki-roots"]
 
 # keep this list sorted!
 [dependencies]
@@ -17,7 +22,8 @@ base64 = "0.13.0"
 futures = "0.3.8"
 http = "0.2.1"
 hyper = { version = "0.14.2", features = ["full"] }
-hyper-tls = "0.5.0"
+hyper-rustls = { version = "0.22.1", optional = true }
+hyper-tls = { version = "0.5.0", optional = true, no-default-features = true }
 opentelemetry = { version = "0.15", features = ["tokio", "rt-tokio"] }
 quick-error = "2.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,9 +178,9 @@ pub struct Consul {
 }
 
 fn https_client() -> HttpsConnector<HttpConnector> {
-    #[cfg(feature="rustls-native")]
+    #[cfg(feature = "rustls-native")]
     return HttpsConnector::with_native_roots();
-    #[cfg(feature="rustls-webpki")]
+    #[cfg(feature = "rustls-webpki")]
     return HttpsConnector::with_webpki_roots();
     #[cfg(feature = "default-tls")]
     return HttpsConnector::new();


### PR DESCRIPTION
In order to compile this crate under MUSL, it would be nice to be able avoid OpenSSL.

This commit adds a feature selection to either enable OpenSSL or Rustls connections.
It provides also a fine control for webpki roots or native roots, to make it easier to compile into self-contained binaries.

By deafult, it will continue using OpenSSL

# What problem are we solving?
# How are we solving the problem?

# Checks
Please check these off before promoting the pull request to non-draft status.
- [ ] All CI checks are green.
- [ ] I have reviewed the proposed changes myself.
