### PR TITLE
ADHOC: Fix wait serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 ### Security
 
+## 0.2.1 - 2022-03-08
+- Fix `wait` serialization for Consul APIs that were missing unit suffix
+
 ## 0.2.0 - 2021-07-20
 ### Added
 - register_entity method and RegisterEntityPayload, and associated, structs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "rs-consul"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Roblox"]
 edition = "2018"
 description = "This crate provides access to a set of strongly typed apis to interact with consul (https://www.consul.io/)"
 readme = "README.md"
 repository = "https://github.com/Roblox/rs-consul"
-license = "MIT"
 license-file = "LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -661,7 +661,11 @@ fn add_query_option_params(uri: &mut String, query_opts: &QueryOptions, mut sepa
         uri.push_str(&format!("{}index={}", separator, idx));
         separator = '&';
         if let Some(wait) = query_opts.wait {
-            uri.push_str(&format!("{}wait={}", separator, wait.as_secs()));
+            uri.push_str(&format!(
+                "{}wait={}",
+                separator,
+                types::duration_as_string(&wait)
+            ));
         }
     }
 }


### PR DESCRIPTION
# What problem are we solving?
We were seeing requests being denied by Consul due to an incorrectly formatted wait time: `RsConsulError(UnexpectedResponseCode(400, \"Invalid wait time\"))`

# How are we solving the problem?
Use the same `duration_as_string` method that we're already using for other paths.

# Checks
Please check these off before promoting the pull request to non-draft status.
- [x] All CI checks are green.
- [x] I have reviewed the proposed changes myself.
