### PR TITLE
Properly handle check and set when it is set to 0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -733,7 +733,7 @@ impl Consul {
 
     fn build_create_or_update_url(&self, request: CreateOrUpdateKeyRequest<'_>) -> String {
         let mut url = String::new();
-        url.push_str(&format!("{}/v1/kv/{}", self.config.address, request.key,));
+        url.push_str(&format!("{}/v1/kv/{}", self.config.address, request.key));
         let mut added_query_param = false;
         if request.flags != 0 {
             url = add_query_param_separator(url, added_query_param);
@@ -750,9 +750,9 @@ impl Consul {
             url.push_str(&format!("release={}", request.release));
             added_query_param = true;
         }
-        if request.check_and_set != 0 {
+        if let Some(cas_idx) = request.check_and_set {
             url = add_query_param_separator(url, added_query_param);
-            url.push_str(&format!("cas={}", request.check_and_set));
+            url.push_str(&format!("cas={}", cas_idx));
         }
 
         add_namespace_and_datacenter(url, request.namespace, request.datacenter)
@@ -1115,6 +1115,67 @@ mod tests {
         assert_eq!(node.address, host);
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn properly_handle_check_and_set() {
+        let consul = get_client();
+        let key = "test/consul/proper_cas_handling";
+        let string_value1 = "This is CAS test";
+        let req = CreateOrUpdateKeyRequest {
+            key,
+            check_and_set: Some(0),
+            ..Default::default()
+        };
+
+        // Key does not exist, with CAS set and modify index set to 0
+        // it should be created.
+        let (set, _) = consul.create_or_update_key(req.clone(), string_value1.as_bytes().to_vec()).await
+            .expect("failed to create key initially");
+        assert!(set);
+        let (value, mod_idx1) = get_single_key_value_with_index(&consul, key).await;
+        assert_eq!(string_value1, &value.unwrap());
+
+        // Subsequent request with CAS set to 0 should not override the
+        // value.
+        let string_value2 = "This is CAS test - not valid";
+        let (set, _) = consul.create_or_update_key(req, string_value2.as_bytes().to_vec()).await
+            .expect("failed to run subsequent create_or_update_key");
+        assert!(!set);
+        // Value and modify index should not have changed because set failed.
+        let (value, mod_idx2) = get_single_key_value_with_index(&consul, key).await;
+        assert_eq!(string_value1, &value.unwrap());
+        assert_eq!(mod_idx1, mod_idx2);
+
+        // Successfully set value with proper CAS value.
+        let req = CreateOrUpdateKeyRequest {
+            key,
+            check_and_set: Some(mod_idx1),
+            ..Default::default()
+        };
+        let string_value3 = "This is correct CAS updated";
+        let (set, _) = consul.create_or_update_key(req, string_value3.as_bytes().to_vec()).await
+            .expect("failed to run create_or_update_key with proper CAS value");
+        assert!(set);
+        // Verify that value was updated and the index changed.
+        let (value, mod_idx3) = get_single_key_value_with_index(&consul, key).await;
+        assert_eq!(string_value3, &value.unwrap());
+        assert_ne!(mod_idx1, mod_idx3);
+
+        // Successfully set value without CAS.
+        let req = CreateOrUpdateKeyRequest {
+            key,
+            check_and_set: None,
+            ..Default::default()
+        };
+        let string_value4 = "This is non CAS update";
+        let (set, _) = consul.create_or_update_key(req, string_value4.as_bytes().to_vec()).await
+            .expect("failed to run create_or_update_key without CAS");
+        assert!(set);
+        // Verify that value was updated and the index changed.
+        let (value, mod_idx4) = get_single_key_value_with_index(&consul, key).await;
+        assert_eq!(string_value4, &value.unwrap());
+        assert_ne!(mod_idx3, mod_idx4);
+    }
+
     fn get_client() -> Consul {
         let conf: Config = Config::from_env();
         Consul::new(conf)
@@ -1159,6 +1220,13 @@ mod tests {
     fn assert_expected_result(res: Result<bool>) {
         assert!(res.is_ok());
         assert!(res.unwrap());
+    }
+
+    async fn get_single_key_value_with_index(consul: &Consul, key: &str) -> (Option<String>, i64) {
+        let res = read_key(consul, key).await
+            .expect("failed to read key");
+        let r = res.into_iter().next().unwrap();
+        (r.value, r.modify_index)
     }
 
     fn verify_single_value_matches(res: Result<Vec<ReadKeyResponse>>, value: &str) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -158,7 +158,7 @@ pub struct CreateOrUpdateKeyRequest<'a> {
     /// This is very useful as a building block for more complex synchronization primitives.
     /// If the index is 0, Consul will only put the key if it does not already exist.
     /// If the index is non-zero, the key is only set if the index matches the ModifyIndex of that key.
-    pub check_and_set: i64,
+    pub check_and_set: Option<i64>,
     /// Supply a session ID to use in a lock acquisition operation.
     /// This is useful as it allows leader election to be built on top of Consul.
     /// If the lock is not held and the session is valid, this increments the LockIndex and sets the Session value of the key in addition to updating the key contents.


### PR DESCRIPTION
# What problem are we solving?

When `check_and_set` is set to 0, the query param is omitted completely
which is valid for use case when we want to update regardless of current
`modify_index`. This however make it impossible to execute requests
with `check_and_set` set to 0, which is also valid use case for setting key
only if it does not already exists.

This is even [stated in the comment](https://github.com/Roblox/rs-consul/blob/main/src/types.rs#L157-L161) however it does not reflect the actual behaviour because the `cas` query param is skipped when the value is 0.

# How are we solving the problem?

Make `check_and_set` an `Option<i64>` to clearly distinguish between 0 and absence of value.

# Important note

This is technically breaking change as programs using current version of 
the library will not compile, therefore it should be included in the next major
version.

# Checks
Please check these off before promoting the pull request to non-draft status.

(Not sure where can I sign CLA. Build will not run automatically for first time contributors.)
- [ ] All CI checks are green.
- [x] I have reviewed the proposed changes myself.
