### PR TITLE
Add datacenter field to Node type

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       consul:
         image: consul:1.9.3
         env:
-          CONSUL_LOCAL_CONFIG: '{"acl": [{"default_policy": "allow", "enable_token_persistence": true, "enabled": true}], "services": [ {"address": "1.1.1.1", "checks": [], "id": "test-service-1", "name": "test-service", "port": 26257} ]}'
+          CONSUL_LOCAL_CONFIG: '{"acl": [{"default_policy": "allow", "enable_token_persistence": true, "enabled": true}], "services": [ {"address": "1.1.1.1", "checks": [], "id": "test-service-1", "name": "test-service", "port": 20001}, {"address": "2.2.2.2", "checks": [], "id": "test-service-2", "name": "test-service", "port": 20002}, {"address": "3.3.3.3", "checks": [], "id": "test-service-3", "name": "test-service", "port": 20003} ]}'
 
     env:
       CONSUL_HTTP_ADDR: http://consul:8500

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,9 +30,9 @@ jobs:
     services:
       consul:
         image: consul:1.9.3
-        options: >-
-          -log-level=debug
-          -e HELLO=1
+        env:
+          CONSUL_LOCAL_CONFIG: 1
+
     env:
       CONSUL_HTTP_ADDR: http://consul:8500
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         image: consul:1.9.3
         options: >-
           -log-level=debug
-          -datacenter=dc1
+          -e HELLO=1
     env:
       CONSUL_HTTP_ADDR: http://consul:8500
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
         image: consul:1.9.3
         options: >-
           -log-level=debug
+          -datacenter=dc1
     env:
       CONSUL_HTTP_ADDR: http://consul:8500
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,8 @@ jobs:
       consul:
         image: consul:1.9.3
         env:
+          # We pass the config as a JSON here to simulate one service with 3 nodes.
+          # TODO: Ideally, we should use the same setup in local environment (`testdata/config.hcl`) in GHA test.
           CONSUL_LOCAL_CONFIG: '{"acl": [{"default_policy": "allow", "enable_token_persistence": true, "enabled": true}], "services": [ {"address": "1.1.1.1", "checks": [], "id": "test-service-1", "name": "test-service", "port": 20001}, {"address": "2.2.2.2", "checks": [], "id": "test-service-2", "name": "test-service", "port": 20002}, {"address": "3.3.3.3", "checks": [], "id": "test-service-3", "name": "test-service", "port": 20003} ]}'
 
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       consul:
         image: consul:1.9.3
         env:
-          CONSUL_LOCAL_CONFIG: 1
+          CONSUL_LOCAL_CONFIG: '{"acl": [{"default_policy": "allow", "enable_token_persistence": true, "enabled": true}], "services": [ {"address": "1.1.1.1", "checks": [], "id": "test-service-1", "name": "test-service", "port": 26257} ]}'
 
     env:
       CONSUL_HTTP_ADDR: http://consul:8500

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,9 +27,16 @@ jobs:
         features: ["", "--no-default-features --features rustls-native"]
     runs-on: "ubuntu-latest"
     container: rust:1.61.0
+    services:
+      consul:
+        image: consul:1.9.3
+        options: >-
+          -log-level=debug
+    env:
+      CONSUL_HTTP_ADDR: http://consul:8500
+
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Consul docker
-        run: docker-compose up -d
+
       - name: Test
         run: cargo test ${{ matrix.features }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,14 +27,9 @@ jobs:
         features: ["", "--no-default-features --features rustls-native"]
     runs-on: "ubuntu-latest"
     container: rust:1.61.0
-    services:
-      consul:
-        image: consul:1.9.3
-    env:
-      CONSUL_HTTP_ADDR: http://consul:8500
-
     steps:
       - uses: actions/checkout@v2
-
+      - name: Setup Consul docker
+        run: docker-compose up -d
       - name: Test
         run: cargo test ${{ matrix.features }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Security
 
 ## 0.2.3 - 2022-08-24
-- Add `datacenter` field to Node
+- Add `datacenter` field to `Node`
 
 ## 0.2.2 - 2022-06-08
 - Add metrics to calls to Consul for increased visibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 ### Security
 
+## 0.2.3 - 2022-08-24
+- Add `datacenter` field to Node
+
 ## 0.2.2 - 2022-06-08
 - Add metrics to calls to Consul for increased visibility
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs-consul"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Roblox"]
 edition = "2018"
 description = "This crate provides access to a set of strongly typed apis to interact with consul (https://www.consul.io/)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,46 +1,6 @@
 version: "3.8"
 
 services:
-  cockroachdb-node-1:
-    container_name: cockroachdb-node-1
-    hostname: cockroachdb-node-1
-    image: cockroachdb/cockroach:v21.1.1
-    command: >-
-      start-single-node
-      --locality=world=global,location=dc-1
-      --accept-sql-without-tls
-      --insecure
-    ports:
-      - 26257:26257 # SQL port
-      - 8080:8080 # Management UI port
-
-  cockroachdb-node-2:
-    container_name: cockroachdb-node-2
-    hostname: cockroachdb-node-2
-    image: cockroachdb/cockroach:v21.1.1
-    depends_on:
-      - cockroachdb-node-1
-    command: >-
-      start
-      --join=cockroachdb-node-1
-      --locality=world=global,location=dc-2
-      --accept-sql-without-tls
-      --insecure
-
-  cockroachdb-node-3:
-    container_name: cockroachdb-node-3
-    hostname: cockroachdb-node-3
-    image: cockroachdb/cockroach:v21.1.1
-    depends_on:
-      - cockroachdb-node-1
-      - cockroachdb-node-2
-    command: >-
-      start
-      --join=cockroachdb-node-1,cockroachdb-node-2
-      --locality=world=global,location=dc-3
-      --accept-sql-without-tls
-      --insecure
-
   consul:
     container_name: consul
     image: consul:1.9.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,6 @@
 version: "3.8"
 
 services:
-  consul:
-    container_name: consul
-    image: consul:1.9.3
-    command: >-
-      consul
-      agent
-      -dev
-      -log-level=debug
-      -recursor=8.8.8.8
-      -client=0.0.0.0
-      -enable-local-script-checks
-    ports:
-      - 8500:8500
-    volumes:
-      - "./testdata:/consul/config"
-    restart: always
-
   cockroachdb-node-1:
     container_name: cockroachdb-node-1
     hostname: cockroachdb-node-1
@@ -57,4 +40,22 @@ services:
       --locality=world=global,location=dc-3
       --accept-sql-without-tls
       --insecure
-  
+
+  consul:
+    container_name: consul
+    image: consul:1.9.3
+    command: >-
+      consul
+      agent
+      -dev
+      -log-level=debug
+      -recursor=8.8.8.8
+      -client=0.0.0.0
+      -enable-local-script-checks
+      -config-file=/consul/config/config.hcl
+      -datacenter=dc1
+    ports:
+      - 8500:8500
+    volumes:
+      - "./testdata:/consul/config"
+    restart: always

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -921,7 +921,7 @@ mod tests {
         assert_eq!(response.len(), 0);
 
         let req = GetServiceNodesRequest {
-            service: "crdb-test-service-one",
+            service: "test-service",
             passing: true,
             ..Default::default()
         };
@@ -930,9 +930,9 @@ mod tests {
 
         let addresses: Vec<String> = response.iter().map(|sn| sn.service.address.clone()).collect();
         let expected_addresses = vec![
-            "cockroachdb-node-1.".to_string(),
-            "cockroachdb-node-2.".to_string(),
-            "cockroachdb-node-3.".to_string(),
+            "1.1.1.1".to_string(),
+            "2.2.2.2".to_string(),
+            "3.3.3.3".to_string(),
         ];
         assert!(expected_addresses
             .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -920,32 +920,25 @@ mod tests {
         let ResponseMeta { response, .. } = consul.get_service_nodes(req, None).await.unwrap();
         assert_eq!(response.len(), 0);
 
-        // TODO: Make these tests pass for nomad and crdb.
-        // let req = GetServiceNodesRequest {
-        //     service: "nomad",
-        //     passing: false,
-        //     ..Default::default()
-        // };
-        // let res = consul.get_service_nodes(req).await.unwrap();
-        // assert_eq!(res.len(), 3);
+        let req = GetServiceNodesRequest {
+            service: "crdb-test-service-one",
+            passing: true,
+            ..Default::default()
+        };
+        let ResponseMeta { response, .. } = consul.get_service_nodes(req, None).await.unwrap();
+        assert_eq!(response.len(), 3);
 
-        // let req = GetServiceNodesRequest {
-        //     service: "crdb-test-service-one",
-        //     passing: true,
-        //     ..Default::default()
-        // };
-        // let res = consul.get_service_nodes(req).await.unwrap();
-        // assert_eq!(res.len(), 3);
+        let addresses: Vec<String> = response.iter().map(|sn| sn.service.address.clone()).collect();
+        let expected_addresses = vec![
+            "cockroachdb-node-1.".to_string(),
+            "cockroachdb-node-2.".to_string(),
+            "cockroachdb-node-3.".to_string(),
+        ];
+        assert!(expected_addresses
+            .iter()
+            .all(|item| addresses.contains(item)));
 
-        // let addresses: Vec<String> = res.into_iter().map(|sn| sn.service.address).collect();
-        // let expected_addresses = vec![
-        //     "cockroachdb-node-1.".to_string(),
-        //     "cockroachdb-node-2.".to_string(),
-        //     "cockroachdb-node-3.".to_string(),
-        // ];
-        // assert!(expected_addresses
-        //     .iter()
-        //     .all(|item| addresses.contains(item)));
+        let _: Vec<_> = response.iter().map(|sn| assert_eq!("dc1", sn.node.datacenter)).collect();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -1080,6 +1073,7 @@ mod tests {
             id: "node".to_string(),
             node: "node".to_string(),
             address: "1.1.1.1".to_string(),
+            datacenter: "datacenter".to_string(),
         };
 
         let service = Service {

--- a/src/types.rs
+++ b/src/types.rs
@@ -415,6 +415,8 @@ pub struct Node {
     pub node: String,
     /// The IP address of the Consul node on which the service is registered.
     pub address: String,
+    /// The datacenter where this node is running on.
+    pub datacenter: String,
 }
 
 #[derive(Clone, Debug, SmartDefault, Serialize, Deserialize, PartialEq)]

--- a/testdata/config.hcl
+++ b/testdata/config.hcl
@@ -4,43 +4,27 @@ acl {
   enable_token_persistence = true
 }
 
-# CockroachDB cluster 'crdb-test-service-one'
+# A service with 3 instances.
 services {
-  id = "crdb-test-service-one-1"
-  name = "crdb-test-service-one"
-  address = "cockroachdb-node-1."
+  id = "test-service-1"
+  name = "test-service"
+  address = "1.1.1.1"
   port = 26257
-  checks = [
-    {
-      args = ["/usr/bin/nc", "-z", "cockroachdb-node-1.", "26257"]
-      interval = "10s"
-      timeout = "5s"
-    }
-  ]
+  checks = []
 }
+
 services {
-  id = "crdb-test-service-one-2"
-  name = "crdb-test-service-one"
-  address = "cockroachdb-node-2."
+  id = "test-service-2"
+  name = "test-service"
+  address = "2.2.2.2"
   port = 26257
-  checks = [
-    {
-      args = ["/usr/bin/nc", "-z", "cockroachdb-node-2.", "26257"]
-      interval = "10s"
-      timeout = "5s"
-    }
-  ]
+  checks = []
 }
+
 services {
-  id = "crdb-test-service-one-3"
-  name = "crdb-test-service-one"
-  address = "cockroachdb-node-3."
+  id = "test-service-3"
+  name = "test-service"
+  address = "3.3.3.3"
   port = 26257
-  checks = [
-    {
-      args = ["/usr/bin/nc", "-z", "cockroachdb-node-3.", "26257"]
-      interval = "10s"
-      timeout = "5s"
-    }
-  ]
+  checks = []
 }

--- a/testdata/config.hcl
+++ b/testdata/config.hcl
@@ -9,7 +9,7 @@ services {
   id = "test-service-1"
   name = "test-service"
   address = "1.1.1.1"
-  port = 26257
+  port = 20001
   checks = []
 }
 
@@ -17,7 +17,7 @@ services {
   id = "test-service-2"
   name = "test-service"
   address = "2.2.2.2"
-  port = 26257
+  port = 20002
   checks = []
 }
 
@@ -25,6 +25,6 @@ services {
   id = "test-service-3"
   name = "test-service"
   address = "3.3.3.3"
-  port = 26257
+  port = 20003
   checks = []
 }


### PR DESCRIPTION
# What problem are we solving?
We need `datacenter` to be able to construct a DNS hostname for a consul service. Specifically, it has the form: `{service_name}.service.{datacenter}.consul`.
# How are we solving the problem?
1. Add `datacenter` attribute to `Node` type.
2. Make `get_cluster_service_nodes` test meaningful by configuring 3 dummy endpoints without any healthchecks. 

# Checks
Please check these off before promoting the pull request to non-draft status.
- [x] All CI checks are green.
- [x] I have reviewed the proposed changes myself.
