### PR TITLE
Introductory PR for lots of changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,11 @@ license-file = "LICENSE"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 default = ["rustls-native"]
-metrics = ["prometheus", "lazy_static"]
+metrics = ["prometheus"]
 default-tls  = ["hyper-tls"]
 rustls-native = ["hyper-rustls/rustls-native-certs"]
 rustls-webpki = ["hyper-rustls/webpki-roots"]
+trace = ["opentelemetry"]
 
 # keep this list sorted!
 [dependencies]
@@ -24,7 +25,7 @@ http = "0.2"
 hyper = { version = "0.14", features = ["full"] }
 hyper-rustls = { version = "0.24" }
 hyper-tls = { version = "0.5.0", optional = true, no-default-features = true }
-lazy_static = { version = "1", optional = true }
+lazy_static = { version = "1" }
 opentelemetry = { version = "0.19", features = ["rt-tokio"], optional = true }
 prometheus = { version = "0.13", optional = true }
 quick-error = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ license-file = "LICENSE"
 [features]
 default = ["rustls-native"]
 metrics = ["prometheus", "lazy_static"]
+default-tls  = ["hyper-tls"]
 rustls-native = ["hyper-rustls/rustls-native-certs"]
 rustls-webpki = ["hyper-rustls/webpki-roots"]
-trace = ["dep:opentelemetry"]
 
 # keep this list sorted!
 [dependencies]
@@ -23,6 +23,7 @@ futures = "0.3"
 http = "0.2"
 hyper = { version = "0.14", features = ["full"] }
 hyper-rustls = { version = "0.24" }
+hyper-tls = { version = "0.5.0", optional = true, no-default-features = true }
 lazy_static = { version = "1", optional = true }
 opentelemetry = { version = "0.19", features = ["rt-tokio"], optional = true }
 prometheus = { version = "0.13", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ futures = "0.3"
 http = "0.2"
 hyper = { version = "0.14", features = ["full"] }
 hyper-rustls = { version = "0.24" }
-hyper-tls = { version = "0.5.0", optional = true, no-default-features = true }
+hyper-tls = { version = "0.5.0", optional = true }
 lazy_static = { version = "1" }
 opentelemetry = { version = "0.19", features = ["rt-tokio"], optional = true }
 prometheus = { version = "0.13", optional = true }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   consul:
     container_name: consul
-    image: consul:1.11.11
+    image: consul:1.15.3
     command: >-
       consul
       agent

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,7 @@ lazy_static! {
 }
 
 const READ_KEY_METHOD_NAME: &str = "read_key";
+const READ_OBJ_METHOD_NAME: &str = "read_obj";
 const CREATE_OR_UPDATE_KEY_METHOD_NAME: &str = "create_or_update_key";
 const CREATE_OR_UPDATE_ALL_METHOD_NAME: &str = "create_or_update_all";
 const CREATE_OR_UPDATE_KEY_SYNC_METHOD_NAME: &str = "create_or_update_key_sync";
@@ -326,7 +327,7 @@ impl Consul {
     /// - request - the [ReadKeyRequest](consul::types::ReadKeyRequest)
     /// # Errors:
     /// [ConsulError](consul::ConsulError) describes all possible errors returned by this api.
-    pub async fn read_key(&self, request: ReadKeyRequest<'_>) -> Result<Vec<ReadKeyResponse>> {
+    pub async fn read_vec(&self, request: ReadKeyRequest<'_>) -> Result<Vec<ReadKeyResponse>> {
         let req = self.build_read_key_req(request);
         let (mut response_body, _index) = self
             .execute_request(req, hyper::Body::empty(), None, READ_KEY_METHOD_NAME)
@@ -343,13 +344,13 @@ impl Consul {
     /// - request - the [ReadKeyRequest](consul::types::ReadKeyRequest)
     /// # Errors:
     /// [ConsulError](consul::ConsulError) describes all possible errors returned by this api.
-    pub async fn read_obj<T>(&self, request: ReadKeyRequest<'_>) -> Result<Vec<ReadKeyResponse<T>>>
+    pub async fn read_key<T>(&self, request: ReadKeyRequest<'_>) -> Result<Vec<ReadKeyResponse<T>>>
     where
         T: DeserializeOwned + Default + std::fmt::Debug,
     {
         let req = self.build_read_key_req(request);
         let (mut response_body, _index) = self
-            .execute_request(req, hyper::Body::empty(), None, READ_KEY_METHOD_NAME)
+            .execute_request(req, hyper::Body::empty(), None, READ_OBJ_METHOD_NAME)
             .await?;
         let bytes = response_body.copy_to_bytes(response_body.remaining());
         serde_json::from_slice::<Vec<ReadKeyResponse<Base64Vec>>>(&bytes)
@@ -1147,7 +1148,7 @@ mod tests {
             .unwrap();
         assert!(res.0);
         let req = ReadKeyRequest::new().set_key(key);
-        let res = consul.read_obj::<ComplexStruct>(req).await.unwrap();
+        let res = consul.read_key::<ComplexStruct>(req).await.unwrap();
         assert_eq!(value, res.into_iter().next().unwrap().value.unwrap());
     }
 
@@ -1504,7 +1505,7 @@ mod tests {
 
     async fn read_string(consul: &Consul, key: &str) -> Result<Vec<ReadKeyResponse<String>>> {
         let req = ReadKeyRequest::new().set_key(key);
-        consul.read_obj::<String>(req).await
+        consul.read_key::<String>(req).await
     }
 
     async fn delete_key(consul: &Consul, key: &str) -> Result<bool> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ use std::{env, str::Utf8Error};
 use base64::Engine;
 use hyper::{body::Buf, client::HttpConnector, Body, Method};
 #[cfg(any(feature = "rustls-native", feature = "rustls-webpki"))]
-use hyper_rustls::{ HttpsConnector, HttpsConnectorBuilder };
+use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 #[cfg(feature = "default-tls")]
 use hyper_tls::HttpsConnector;
 use lazy_static::lazy_static;
@@ -251,7 +251,6 @@ where
 #[derive(Debug)]
 /// This struct defines the consul client and allows access to the consul api via method syntax.
 pub struct Consul {
-
     https_client: hyper::Client<HttpsConnector<HttpConnector>, Body>,
     config: Config,
     #[cfg(feature = "trace")]
@@ -275,7 +274,7 @@ fn https_connector() -> HttpsConnector<HttpConnector> {
     {
         let mut conn = HttpsConnector::new();
         conn.https_only(false);
-        return conn; 
+        return conn;
     }
 }
 
@@ -865,7 +864,7 @@ impl Consul {
         &self,
         service_name: &str,
         query_opts: Option<QueryOptions>,
-    ) -> Result<Vec<(String, u16)>> {
+    ) -> Result<Vec<(String, Option<u16>)>> {
         let request = GetServiceNodesRequest {
             service: service_name,
             passing: true,
@@ -903,12 +902,12 @@ impl Consul {
     /// in the health endpoint. These requests models are primarily for the
     /// health endpoints
     /// https://www.consul.io/api-docs/health#list-nodes-for-service
-    fn parse_host_port_from_service_node_response(sn: ServiceNode) -> (String, u16) {
+    fn parse_host_port_from_service_node_response(sn: ServiceNode) -> (String, Option<u16>) {
         (
             if sn.service.address.is_empty() {
                 info!(
-                    "Consul service {service_name} instance had an empty Service address, with port:{port}",
-                    service_name = &sn.service.service, port = sn.service.port
+                    "Consul service {} instance had an empty Service address, with port:{:?}",
+                    &sn.service.service, sn.service.port
                 );
                 sn.node.address
             } else {
@@ -1511,14 +1510,14 @@ mod tests {
             id: "node".to_string(),
             service: "node".to_string(),
             address: "2.2.2.2".to_string(),
-            port: 32,
+            port: Some(32),
         };
 
         let empty_service = Service {
             id: "".to_string(),
             service: "".to_string(),
             address: "".to_string(),
-            port: 32,
+            port: Some(32),
         };
 
         let sn = ServiceNode {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,15 @@ impl Config {
             hyper_builder: Default::default(),
         }
     }
+
+    /// Create a new config from an address and token
+    pub fn new(address: String, token: Option<String>) -> Self {
+        Config {
+            address,
+            token,
+            hyper_builder: Default::default(),
+        }
+    }
 }
 
 /// Represents a lock against Consul.
@@ -1276,7 +1285,7 @@ mod tests {
         for sn in list_response.response.iter() {
             let dereg_request = DeregisterEntityRequest {
                 node: "local",
-                service_id: Some(sn.service.id.as_str()),
+                service_id: Some(sn.service_id.as_ref().unwrap().as_str()),
                 ..Default::default()
             };
             consul.deregister_entity(&dereg_request).await.unwrap();
@@ -1349,7 +1358,7 @@ mod tests {
 
         let addresses: Vec<String> = response
             .iter()
-            .map(|sn| sn.service.address.clone())
+            .map(|sn| sn.service_address.as_ref().unwrap().clone())
             .collect();
         let expected_addresses = vec![
             "1.1.1.1".to_string(),
@@ -1362,7 +1371,7 @@ mod tests {
 
         let _: Vec<_> = response
             .iter()
-            .map(|sn| assert_eq!("dc1", sn.node.datacenter))
+            .map(|sn| assert_eq!("dc1", sn.datacenter))
             .collect();
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -117,6 +117,37 @@ pub struct ReadKeyRequest<'a> {
     pub wait: Duration,
 }
 
+macro_rules! builder_fun {
+    ($nm:ident, $fun:ident, $parm:ty) => {
+        /// Builder-style method to set $nm on the object and return `self`
+        pub fn $fun(self, $nm: $parm) -> Self {
+            ReadKeyRequest { $nm, ..self }
+        }
+    };
+}
+impl<'a> ReadKeyRequest<'a> {
+    /// Construct a default ReadKeyRequest to be used with the builder API
+    /// e.g.
+    /// ```rust
+    /// let req = ReadKeyRequest::new()
+    ///     .set_key("bar")
+    ///     .set_namespace("foo")
+    ///     .recurse(true);
+    /// ```
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    builder_fun!(key, set_key, &'a str);
+    builder_fun!(namespace, set_namespace, &'a str);
+    builder_fun!(datacenter, set_datacenter, &'a str);
+    builder_fun!(recurse, set_recurse, bool);
+    builder_fun!(separator, set_separator, &'a str);
+    builder_fun!(consistency, set_consistency, ConsistencyMode);
+    builder_fun!(index, set_index, Option<u64>);
+    builder_fun!(wait, set_wait, Duration);
+}
+
 /// Represents a request to read a key from Consul's Key Value store.
 #[derive(Clone, Debug, SmartDefault, Serialize, Deserialize, PartialEq)]
 pub struct LockWatchRequest<'a> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -71,7 +71,7 @@ pub struct ResponseMeta<T> {
 }
 
 /// Represents a request to delete a key or all keys sharing a prefix from Consul's Key Value store.
-#[derive(Clone, Debug, SmartDefault, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, SmartDefault, Serialize, PartialEq, Eq)]
 pub struct DeleteKeyRequest<'a> {
     /// Specifies the path of the key to delete.
     pub key: &'a str,
@@ -91,7 +91,7 @@ pub struct DeleteKeyRequest<'a> {
 }
 
 /// Represents a request to read a key from Consul's Key Value store.
-#[derive(Clone, Debug, SmartDefault, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, SmartDefault, Serialize, PartialEq, Eq)]
 pub struct ReadKeyRequest<'a> {
     /// Specifies the path of the key to read.
     pub key: &'a str,
@@ -129,10 +129,11 @@ impl<'a> ReadKeyRequest<'a> {
     /// Construct a default ReadKeyRequest to be used with the builder API
     /// e.g.
     /// ```rust
+    /// use rs_consul::ReadKeyRequest;
     /// let req = ReadKeyRequest::new()
     ///     .set_key("bar")
     ///     .set_namespace("foo")
-    ///     .recurse(true);
+    ///     .set_recurse(true);
     /// ```
     pub fn new() -> Self {
         Default::default()
@@ -149,7 +150,7 @@ impl<'a> ReadKeyRequest<'a> {
 }
 
 /// Represents a request to read a key from Consul's Key Value store.
-#[derive(Clone, Debug, SmartDefault, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, SmartDefault, Serialize, PartialEq, Eq)]
 pub struct LockWatchRequest<'a> {
     /// Specifies the path of the key to read.
     pub key: &'a str,
@@ -171,7 +172,7 @@ pub struct LockWatchRequest<'a> {
 }
 
 /// Represents a request to read a key from Consul Key Value store.
-#[derive(Clone, Debug, SmartDefault, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, SmartDefault, Serialize, PartialEq, Eq)]
 pub struct CreateOrUpdateKeyRequest<'a> {
     /// Specifies the path of the key.
     pub key: &'a str,
@@ -265,7 +266,7 @@ pub struct ReadKeyResponse<T: Default = Base64Vec> {
 }
 
 /// Represents a request to create a lock .
-#[derive(Clone, Debug, SmartDefault, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, SmartDefault, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct LockRequest<'a> {
     /// The key to use for locking.
@@ -338,7 +339,7 @@ pub struct SessionResponse {
     pub id: String,
 }
 
-#[derive(Clone, Debug, SmartDefault, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, SmartDefault, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub(crate) struct CreateSessionRequest {
     #[default(_code = "Duration::from_secs(0)")]
@@ -359,93 +360,122 @@ pub(crate) struct CreateSessionRequest {
 
 /// Payload struct to register or update entries in consul's catalog.
 /// See https://www.consul.io/api-docs/catalog#register-entity for more information.
-#[allow(non_snake_case)]
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct RegisterEntityPayload {
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct RegisterEntityRequest<'a> {
     /// Optional UUID to assign to the node. This string is required to be 36-characters and UUID formatted.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ID: Option<String>,
+    #[serde(rename = "ID")]
+    pub id: Option<&'a str>,
     /// Node ID to register.
-    pub Node: String,
+    pub node: &'a str,
     /// The address to register.
-    pub Address: String,
+    pub address: &'a str,
     /// The datacenter to register in, defaults to the agent's datacenter.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub Datacenter: Option<String>,
+    pub datacenter: Option<&'a str>,
     /// Tagged addressed to register with.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub TaggedAddresses: HashMap<String, String>,
+    pub tagged_addresses: HashMap<&'a str, &'a str>,
     /// KV metadata paris to register with.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub NodeMeta: HashMap<String, String>,
+    pub node_meta: HashMap<&'a str, &'a str>,
     /// Optional service to register.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub Service: Option<RegisterEntityService>,
+    pub service: Option<RegisterEntityService<'a>>,
     /// Optional check to register
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub Check: Option<RegisterEntityCheck>,
+    pub check: Option<RegisterEntityCheck>,
     /// Whether to skip updating the nodes information in the registration.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub SkipNodeUpdate: Option<bool>,
+    pub skip_node_update: Option<bool>,
 }
 
 /// The service to register with consul's global catalog.
 /// See https://www.consul.io/api/agent/service for more information.
-#[allow(non_snake_case)]
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct RegisterEntityService {
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct RegisterEntityService<'a> {
     /// ID to register service will, defaults to Service.Service property.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ID: Option<String>,
+    #[serde(rename = "ID")]
+    pub id: Option<&'a str>,
     /// The name of the service.
-    pub Service: String,
+    pub service: &'a str,
     /// Optional tags associated with the service.
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub Tags: Vec<String>,
+    pub tags: Vec<&'a str>,
     /// Optional map of explicit LAN and WAN addresses for the service.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub TaggedAddresses: HashMap<String, String>,
+    pub tagged_addresses: HashMap<&'a str, &'a str>,
     /// Optional key value meta associated with the service.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub Meta: HashMap<String, String>,
+    pub meta: HashMap<&'a str, &'a str>,
     /// The port of the service
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub Port: Option<u16>,
+    pub port: Option<u16>,
     /// The consul namespace to register the service in.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub Namespace: Option<String>,
+    pub namespace: Option<&'a str>,
 }
 
 /// Information related to registering a check.
 /// See https://www.consul.io/docs/discovery/checks for more information.
-#[allow(non_snake_case)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
 pub struct RegisterEntityCheck {
     /// The node to execute the check on.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub Node: Option<String>,
+    pub node: Option<String>,
     /// Optional check id, defaults to the name of the check.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub CheckID: Option<String>,
+    #[serde(rename = "CheckID")]
+    pub check_id: Option<String>,
     /// The name associated with the check
-    pub Name: String,
+    pub name: String,
     /// Opaque field encapsulating human-readable text.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub Notes: Option<String>,
+    pub notes: Option<String>,
     /// The status of the check. Must be one of 'passing', 'warning', or 'critical'.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub Status: Option<String>,
+    pub status: Option<String>,
     /// ID of the service this check is for. If no ID of a service running on the node is provided,
     /// the check is treated as a node level check
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ServiceID: Option<String>,
+    #[serde(rename = "ServiceID")]
+    pub service_id: Option<String>,
     /// Details for a TCP or HTTP health check.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub Definition: HashMap<String, String>,
+    pub definition: HashMap<String, String>,
+}
+
+/// Request body for de-registering a check or service from the Catalog
+/// See https://developer.hashicorp.com/consul/api-docs/catalog#deregister-entity for more
+/// information
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct DeregisterEntityRequest<'a> {
+    /// The node on which to execute the registration
+    pub node: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Optional string to specify which datacenter to find the node. If not supplied, defaults to
+    /// the DC of the agent to which this client is connected
+    pub datacenter: Option<&'a str>,
+    /// Specifies the ID of the Check to remove
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "CheckID")]
+    pub check_id: Option<&'a str>,
+    /// Specifies the ID of the Service to remove 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "ServiceID")]
+    pub service_id: Option<&'a str>,
+    /// The consul namespace to register the service in.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<&'a str>,
 }
 
 /// Request for the nodes providing a specified service registered in Consul.
-#[derive(Clone, Debug, SmartDefault, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, SmartDefault, Serialize, PartialEq, Eq)]
 pub struct GetServiceNodesRequest<'a> {
     /// Specifies the service to list services for. This is provided as part of the URL.
     pub service: &'a str,
@@ -487,8 +517,10 @@ pub struct Node {
     /// The datacenter where this node is running on.
     pub datacenter: String,
     /// List of explicit WAN and LAN addresses for the node
+    #[serde(deserialize_with = "null_to_default")]
     pub tagged_addresses: HashMap<String, String>,
     /// Map of metadata options
+    #[serde(deserialize_with = "null_to_default")]
     pub meta: HashMap<String, String>,
 }
 
@@ -589,3 +621,26 @@ impl<'de> Deserialize<'de> for Base64Vec {
         deserializer.deserialize_str(Vis)
     }
 }
+
+impl From<Vec<u8>> for Base64Vec {
+    fn from(a: Vec<u8>) -> Base64Vec {
+        Base64Vec(a)
+    }
+}
+
+impl From<Base64Vec> for Vec<u8> {
+    fn from(a: Base64Vec) -> Vec<u8> {
+        a.0
+    }
+}
+
+fn null_to_default<'de, D, T>(d: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Default + Deserialize<'de>,
+{
+    let opt = Option::deserialize(d)?;
+    let val = opt.unwrap_or_else(T::default);
+    Ok(val)
+}
+

--- a/src/types.rs
+++ b/src/types.rs
@@ -465,7 +465,7 @@ pub struct DeregisterEntityRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "CheckID")]
     pub check_id: Option<&'a str>,
-    /// Specifies the ID of the Service to remove 
+    /// Specifies the ID of the Service to remove
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "ServiceID")]
     pub service_id: Option<&'a str>,
@@ -640,7 +640,6 @@ where
     T: Default + Deserialize<'de>,
 {
     let opt = Option::deserialize(d)?;
-    let val = opt.unwrap_or_else(T::default);
+    let val = opt.unwrap_or_default();
     Ok(val)
 }
-

--- a/src/types.rs
+++ b/src/types.rs
@@ -204,10 +204,10 @@ pub struct CreateOrUpdateKeyRequest<'a> {
     pub release: &'a str,
 }
 
-/// Represents a request to read a key from Consul Key Value store.
+/// Represents a response from reading a key from Consul Key Value store.
 #[derive(Clone, Debug, SmartDefault, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "PascalCase")]
-pub struct ReadKeyResponse {
+pub struct ReadKeyResponse<T: Default = Vec<u8>> {
     /// CreateIndex is the internal index value that represents when the entry was created.
     pub create_index: i64,
     /// ModifyIndex is the last index that modified this key.
@@ -223,7 +223,7 @@ pub struct ReadKeyResponse {
     /// Clients can choose to use this however makes sense for their application.
     pub flags: u64,
     /// Value is a base64-encoded blob of data.
-    pub value: Option<String>,
+    pub value: Option<T>,
     /// If a lock is held, the Session key provides the session that owns the lock.
     pub session: Option<String>,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -507,6 +507,7 @@ pub struct ServiceNode {
 #[derive(Clone, Debug, SmartDefault, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 /// The node information of an instance providing a Consul service.
+/// provided by the Consul Health API
 pub struct Node {
     /// The ID of the service node.
     #[serde(rename = "ID")]
@@ -523,6 +524,30 @@ pub struct Node {
     /// Map of metadata options
     #[serde(deserialize_with = "null_to_default")]
     pub meta: HashMap<String, String>,
+}
+
+#[derive(Clone, Debug, SmartDefault, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "PascalCase")]
+/// The node information as returned by the Consul Catalog API
+pub struct NodeFull {
+    id: String,
+    node: String,
+    address: String,
+    datacenter: String,
+    tagged_addresses: HashMap<String, String>,
+    node_meta: HashMap<String, String>,
+    create_index: u64,
+    modify_index: u64,
+    service_address: Option<String>,
+    service_enable_tag_override: Option<bool>,
+    #[serde(rename = "Service_ID")]
+    service_id: Option<String>,
+    service_name: Option<String>,
+    service_port: Option<u16>,
+    service_meta: HashMap<String, String>,
+    service_tagged_addresses: HashMap<String, String>,
+    service_tags: Vec<String>,
+    namespace: Option<String>,
 }
 
 #[derive(Clone, Debug, SmartDefault, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -218,7 +218,8 @@ pub struct TransactionOp<'a> {
     pub value: Base64Vec,
     #[serde(rename = "Index")]
     /// The modify_index if it is a cas operation
-    pub check_and_set: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub check_and_set: Option<u64>,
     /// Optional flags to associate with the key
     pub flags: u64,
     /// Namespace on which to operate

--- a/src/types.rs
+++ b/src/types.rs
@@ -534,24 +534,41 @@ pub struct Node {
 #[serde(rename_all = "PascalCase")]
 /// The node information as returned by the Consul Catalog API
 pub struct NodeFull {
-    id: String,
-    node: String,
-    address: String,
-    datacenter: String,
-    tagged_addresses: HashMap<String, String>,
-    node_meta: HashMap<String, String>,
-    create_index: u64,
-    modify_index: u64,
-    service_address: Option<String>,
-    service_enable_tag_override: Option<bool>,
+    /// id
+    pub id: String,
+    /// node 
+    pub node: String,
+    /// address
+    pub address: String,
+    /// datacenter
+    pub datacenter: String,
+    /// tagged_addresses
+    pub tagged_addresses: HashMap<String, String>,
+    /// node_meta
+    pub node_meta: HashMap<String, String>,
+    /// create_index
+    pub create_index: u64,
+    /// modify_index
+    pub modify_index: u64,
+    /// service_address
+    pub service_address: Option<String>,
+    /// service_enable_tag_override
+    pub service_enable_tag_override: Option<bool>,
     #[serde(rename = "Service_ID")]
-    service_id: Option<String>,
-    service_name: Option<String>,
-    service_port: Option<u16>,
-    service_meta: HashMap<String, String>,
-    service_tagged_addresses: HashMap<String, String>,
-    service_tags: Vec<String>,
-    namespace: Option<String>,
+    /// service_id
+    pub service_id: Option<String>,
+    /// service_name
+    pub service_name: Option<String>,
+    /// service_port
+    pub service_port: Option<u16>,
+    /// service_meta
+    pub service_meta: HashMap<String, String>,
+    /// service_tagged_addresses
+    pub service_tagged_addresses: HashMap<String, String>,
+    /// service_tags
+    pub service_tags: Vec<String>,
+    ///  namespace
+    pub namespace: Option<String>,
 }
 
 #[derive(Clone, Debug, SmartDefault, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -532,6 +532,7 @@ pub struct Node {
 /// The node information as returned by the Consul Catalog API
 pub struct NodeFull {
     /// id
+    #[serde(rename = "ID")]
     pub id: String,
     /// node
     pub node: String,
@@ -561,7 +562,7 @@ pub struct NodeFull {
     /// service_meta
     pub service_meta: HashMap<String, String>,
     /// service_tagged_addresses
-    pub service_tagged_addresses: HashMap<String, String>,
+    pub service_tagged_addresses: HashMap<String, HashMap<String, serde_json::Value>>,
     /// service_tags
     pub service_tags: Vec<String>,
     ///  namespace

--- a/src/types.rs
+++ b/src/types.rs
@@ -25,12 +25,9 @@ SOFTWARE.
 use std::collections::HashMap;
 use std::time::Duration;
 
+use base64::{engine::general_purpose::STANDARD as B64, Engine};
 use serde::{self, de::Deserializer, de::Error as SerdeError, Deserialize, Serialize, Serializer};
 use smart_default::SmartDefault;
-use base64::{ 
-    Engine, 
-    engine::general_purpose::STANDARD as B64,
-};
 
 // TODO retrofit other get APIs to use this struct
 /// Query options for Consul endpoints.
@@ -536,7 +533,7 @@ pub struct Node {
 pub struct NodeFull {
     /// id
     pub id: String,
-    /// node 
+    /// node
     pub node: String,
     /// address
     pub address: String,
@@ -583,7 +580,7 @@ pub struct Service {
     /// The address of the instance.
     pub address: String,
     /// The port of the instance.
-    pub port: u16,
+    pub port: Option<u16>,
 }
 
 pub(crate) fn serialize_duration_as_string<S>(

--- a/src/types.rs
+++ b/src/types.rs
@@ -27,6 +27,10 @@ use std::time::Duration;
 
 use serde::{self, de::Deserializer, de::Error as SerdeError, Deserialize, Serialize, Serializer};
 use smart_default::SmartDefault;
+use base64::{ 
+    Engine, 
+    engine::general_purpose::STANDARD as B64,
+};
 
 // TODO retrofit other get APIs to use this struct
 /// Query options for Consul endpoints.
@@ -623,10 +627,7 @@ pub struct Base64Vec(pub Vec<u8>);
 
 impl Serialize for Base64Vec {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.collect_str(&base64::display::Base64Display::with_config(
-            &self.0,
-            base64::STANDARD,
-        ))
+        serializer.collect_str(&B64.encode(&self.0))
     }
 }
 
@@ -641,7 +642,7 @@ impl<'de> Deserialize<'de> for Base64Vec {
             }
 
             fn visit_str<E: SerdeError>(self, v: &str) -> Result<Self::Value, E> {
-                base64::decode(v).map(Base64Vec).map_err(SerdeError::custom)
+                B64.decode(v).map(Base64Vec).map_err(SerdeError::custom)
             }
         }
         deserializer.deserialize_str(Vis)

--- a/src/types.rs
+++ b/src/types.rs
@@ -84,7 +84,7 @@ pub struct DeleteKeyRequest<'a> {
     /// This is very useful as a building block for more complex synchronization primitives.
     /// The index must be greater than 0 for Consul to take any action: a 0 index will not delete the key.
     /// If the index is non-zero, the key is only deleted if the index matches the ModifyIndex of that key.
-    pub check_and_set: u32,
+    pub check_and_set: Option<u64>,
     /// Specifies the namespace to query.
     /// If not provided, the namespace will be inferred from the request's ACL token, or will default to the default namespace.
     pub namespace: &'a str,
@@ -190,7 +190,7 @@ pub struct CreateOrUpdateKeyRequest<'a> {
     /// This is very useful as a building block for more complex synchronization primitives.
     /// If the index is 0, Consul will only put the key if it does not already exist.
     /// If the index is non-zero, the key is only set if the index matches the ModifyIndex of that key.
-    pub check_and_set: Option<i64>,
+    pub check_and_set: Option<u64>,
     /// Supply a session ID to use in a lock acquisition operation.
     /// This is useful as it allows leader election to be built on top of Consul.
     /// If the lock is not held and the session is valid, this increments the LockIndex and sets the Session value of the key in addition to updating the key contents.


### PR DESCRIPTION
# What problem are we solving?

I have been building some systems against this library for the last couple of days and made a bunch of changes to my fork.  These changes include additional functions, but also updates the rs-consul code to make it more "idiomatic Rust".  

A couple of these changes do break backwards compatibility a bit, but not a lot.  This would probably warrant a new minor version.   

This is a lot of changes, so it might need to be broken up into a few separate PRs, which I'm willing to do.  I'd just like to put this out there to get some feedback first. 

Here is an incomplete list of changes: 

## Introduced a `Base64Vec` type

This is mostly used under the hood to simplify sending `Vec<u8>` to and from Consul.  It transparently base64 encodes and decodes with a custom Serializer and Deserializer.  
`ReadKeyRequest` is generic over T (see below) but defaults to Base64Vec. 

## Changed all KV related operations to be generic over type T

Previously one had to write `Vec<u8>` and read a `String`, which I found to be a little awkward. 
In all cases,  T must implement `Serialize` or `Deserialize` + `Debug` + `Default` and in some cases (get_lock) it requres `Clone` as well.  
If all you're doing is storing and retrieving `String` this interface should be a bit simpler, because you don't have to convert to and from Vec<u8> 

Methods updated to be Generic over T: 
- create_or_update_key
- read_key
- get_lock
- get_lock_inner

Structs updated to be generic over T: 
- LockGuard (was Lock) 
- ReadKeyResponse

## Added Transaction operations 
You can now send batches of operations to be executed with (some?) isolation using Consuls txn API. (see https://developer.hashicorp.com/consul/api-docs/txn) 

This includes new a new method: `create_or_update_all`  which takes a Vec of `TransactionOp`.  Note that I didn't add support for all request types into TransactionOp, only KV, which is all that I needed. 

Note that TransactionOp is not generic over T, because A `Vec<TransactionOp<T>>` would allow only 1 type of value to be written. So it takes a Base64Vec as a value instead. 

## Tests are idempotent, for the most part 
The tests assumed that the database was pristine, so some tests would fail on multiple runs.  This is no longer the case.  They now clean up before their operations. 

## Exposed `create_session` and made a `get_lock_inner` 

For those that don't want to use a LockGuard with `drop` semantics, because they have their own system for managing locks,  I've exposed the inner workings of `get_lock` 

## Made everything more self-consistent and idiomatic Rust 

- Some of the Requests were called `*Payload`  now they're all called `*Request` 
- Some requests took `String`s while others took `&str` - Now they all take &str
- Some structs had members which were PascalCase and had an `allow` attr.   These have been changed to snake_case, and use `serde_rename = "PascalCase"` instead, like the other structs. 


# Checks
Please check these off before promoting the pull request to non-draft status.
- [ ] All CI checks are green.
- [ ] I have reviewed the proposed changes myself.
