### PR TITLE
Update opentelemetry to 0.18 and make it optional via a feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - `default-tls`, `rustls-native`, and `rustls-webpki` features to allow usage of rustls for the https client
 ### Changed
+- `opentelemetry` feature must be specified to enable opentelemetry support.
+- `opentelemetry` updated to version `0.18`.
+- `base64` updated to version `0.20`.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,18 @@ default-tls  = ["hyper-tls"]
 metrics = ["prometheus", "lazy_static"]
 rustls-native = ["hyper-rustls/rustls-native-certs"]
 rustls-webpki = ["hyper-rustls/webpki-roots"]
+opentelemetry = ["dep:opentelemetry"]
 
 # keep this list sorted!
 [dependencies]
-base64 = "0.13.0"
+base64 = "0.20.0"
 futures = "0.3.8"
 http = "0.2.1"
 hyper = { version = "0.14.2", features = ["full"] }
 hyper-rustls = { version = "0.22.1", optional = true }
-hyper-tls = { version = "0.5.0", optional = true, no-default-features = true }
+hyper-tls = { version = "0.5.0", optional = true, default-features = true }
 lazy_static = { version = "1.4.0", optional = true }
-opentelemetry = { version = "0.15", features = ["tokio", "rt-tokio"] }
+opentelemetry = { version = "0.18", features = ["rt-tokio"], optional = true }
 prometheus = { version = "0.13", optional = true }
 quick-error = "2.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/hyper_wrapper.rs
+++ b/src/hyper_wrapper.rs
@@ -25,7 +25,7 @@ SOFTWARE.
 use hyper::Version;
 use opentelemetry::{
     global::{BoxedSpan, BoxedTracer},
-    trace::{Span, StatusCode, Tracer},
+    trace::{Span, Status, Tracer},
     KeyValue,
 };
 
@@ -84,6 +84,6 @@ pub fn annotate_span_for_response<T>(span: &mut BoxedSpan, response: &hyper::Res
     }
 
     if status != hyper::StatusCode::OK {
-        span.set_status(StatusCode::Error, status.as_str().to_owned());
+        span.set_status(Status::error(status.as_str().to_owned()));
     }
 }


### PR DESCRIPTION
# What problem are we solving?

* openteletry support is using a very old version
* openteletry might be unnecessary to most users, and there's precedent (prometheus metrics) for making such things optional with features.

# How are we solving the problem?

Update opentelemetry to 0.18 and make it optional via a feature

# Checks
Please check these off before promoting the pull request to non-draft status.
- [ ] All CI checks are green.
- [x] I have reviewed the proposed changes myself.
