### PR TITLE
Add hyper_builder field to Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 ### Added
+- `hyper_builder` field was added to `Config` in order to allow specifying additional hyper options.
 - `default-tls`, `rustls-native`, and `rustls-webpki` features to allow usage of rustls for the https client
 ### Changed
 ### Deprecated

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ futures = "0.3.8"
 http = "0.2.1"
 hyper = { version = "0.14.2", features = ["full"] }
 hyper-rustls = { version = "0.22.1", optional = true }
-hyper-tls = { version = "0.5.0", optional = true, no-default-features = true }
+hyper-tls = { version = "0.5.0", optional = true, default-features = true }
 lazy_static = { version = "1.4.0", optional = true }
 opentelemetry = { version = "0.15", features = ["tokio", "rt-tokio"] }
 prometheus = { version = "0.13", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,10 @@ pub struct Config {
     pub address: String,
     /// The consul secret token to make authenticated requests to the consul server.
     pub token: Option<String>,
+
+    /// The hyper builder for the internal http client.
+    #[serde(skip)]
+    pub hyper_builder: hyper::client::Builder,
 }
 
 impl Config {
@@ -165,6 +169,7 @@ impl Config {
         Config {
             address: addr,
             token: Some(token),
+            hyper_builder: Default::default(),
         }
     }
 }
@@ -233,7 +238,7 @@ impl Consul {
     /// - [Config](consul::Config)
     pub fn new(config: Config) -> Self {
         let https = https_client();
-        let https_client = hyper::Client::builder().build::<_, hyper::Body>(https);
+        let https_client = config.hyper_builder.build::<_, hyper::Body>(https);
         Consul {
             https_client,
             config,


### PR DESCRIPTION
# What problem are we solving?

Providing additional options to the underlying hyper client. Otherwise, things like connection pool size cannot be specified. In my case it's needed in order to work around this [bug](https://github.com/hyperium/hyper/issues/2312).

# How are we solving the problem?

Add hyper_builder field to Config.

# Checks
Please check these off before promoting the pull request to non-draft status.
- [ ] All CI checks are green.
- [x] I have reviewed the proposed changes myself.
