### PR TITLE
Add support for deregister entity

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,9 +498,7 @@ impl Consul {
     /// - payload: The [`DeregisterEntityPayload`](DeregisterEntityPayload) to provide the register entity API.
     /// # Errors:
     /// [ConsulError](consul::ConsulError) describes all possible errors returned by this api.
-    pub async fn deregister_entity(
-        &self,
-        payload: &DeregisterEntityPayload) -> Result<()> {
+    pub async fn deregister_entity(&self, payload: &DeregisterEntityPayload) -> Result<()> {
         let uri = format!("{}/v1/catalog/deregister", self.config.address);
         let request = hyper::Request::builder().method(Method::PUT).uri(uri);
         let payload = serde_json::to_string(payload).map_err(ConsulError::InvalidRequest)?;
@@ -936,14 +934,15 @@ mod tests {
         let node_id = "local";
         register_entity(&consul, &new_service_name, node_id).await;
 
-        let payload = DeregisterEntityPayload { 
-            Node: Some(node_id.to_string()), 
-            Datacenter: None, 
-            CheckID: None, 
-            ServiceID: None, 
-            Namespace:  None,
+        let payload = DeregisterEntityPayload {
+            Node: Some(node_id.to_string()),
+            Datacenter: None,
+            CheckID: None,
+            ServiceID: None,
+            Namespace: None,
         };
-        consul.deregister_entity(&payload)
+        consul
+            .deregister_entity(&payload)
             .await
             .expect("expected deregister_entity request to succeed");
 
@@ -1213,7 +1212,7 @@ mod tests {
         assert_ne!(mod_idx3, mod_idx4);
     }
 
-    async fn register_entity(consul: &Consul, service_name: &String, node_id: &str)  {
+    async fn register_entity(consul: &Consul, service_name: &String, node_id: &str) {
         let ResponseMeta {
             response: service_names_before_register,
             ..

--- a/src/types.rs
+++ b/src/types.rs
@@ -320,6 +320,28 @@ pub struct RegisterEntityPayload {
     pub SkipNodeUpdate: Option<bool>,
 }
 
+/// The service to deregister with consul's global catalog.
+/// See https://www.consul.io/api/agent/service for more information.
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DeregisterEntityPayload {
+    /// The node to execute the check on.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub Node: Option<String>,
+    /// The datacenter to register in, defaults to the agent's datacenter.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub Datacenter: Option<String>,
+    /// Specifies the ID of the check to remove.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub CheckID: Option<String>,
+    /// Specifies the ID of the service to remove. The service and all associated checks will be removed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ServiceID: Option<String>,
+    /// Specifies the namespace of the service and checks you deregister.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub Namespace: Option<String>,
+}
+
 /// The service to register with consul's global catalog.
 /// See https://www.consul.io/api/agent/service for more information.
 #[allow(non_snake_case)]


### PR DESCRIPTION
# What problem are we solving?

Deregister entity is not supported by this library, but it is by Consul's API: https://www.consul.io/api-docs/catalog#deregister-entity  

# How are we solving the problem?
Adding support :)

# Checks
Please check these off before promoting the pull request to non-draft status.
- [ ] All CI checks are green.
- [x] I have reviewed the proposed changes myself.
