### PR TITLE
Deserialize tags into Service struct

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           # We pass the config as a JSON here to simulate one service with 3 nodes.
           # TODO: Ideally, we should use the same setup in local environment (`testdata/config.hcl`) in GHA test.
-          CONSUL_LOCAL_CONFIG: '{"acl": [{"default_policy": "allow", "enable_token_persistence": true, "enabled": true}], "services": [ {"address": "1.1.1.1", "checks": [], "id": "test-service-1", "name": "test-service", "port": 20001}, {"address": "2.2.2.2", "checks": [], "id": "test-service-2", "name": "test-service", "port": 20002}, {"address": "3.3.3.3", "checks": [], "id": "test-service-3", "name": "test-service", "port": 20003} ]}'
+          CONSUL_LOCAL_CONFIG: '{"acl": [{"default_policy": "allow", "enable_token_persistence": true, "enabled": true}], "services": [ {"address": "1.1.1.1", "checks": [], "id": "test-service-1", "name": "test-service", "port": 20001, "tags": ["first"]}, {"address": "2.2.2.2", "checks": [], "id": "test-service-2", "name": "test-service", "port": 20002, "tags": ["second"]}, {"address": "3.3.3.3", "checks": [], "id": "test-service-3", "name": "test-service", "port": 20003, "tags": ["third"]} ]}'
 
     env:
       CONSUL_HTTP_ADDR: http://consul:8500

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
         env:
           # We pass the config as a JSON here to simulate one service with 3 nodes.
           # TODO: Ideally, we should use the same setup in local environment (`testdata/config.hcl`) in GHA test.
-          CONSUL_LOCAL_CONFIG: '{"acl": [{"default_policy": "allow", "enable_token_persistence": true, "enabled": true}], "services": [ {"address": "1.1.1.1", "checks": [], "id": "test-service-1", "name": "test-service", "port": 20001}, {"address": "2.2.2.2", "checks": [], "id": "test-service-2", "name": "test-service", "port": 20002}, {"address": "3.3.3.3", "checks": [], "id": "test-service-3", "name": "test-service", "port": 20003} ]}'
+          CONSUL_LOCAL_CONFIG: '{"acl": [{"default_policy": "allow", "enable_token_persistence": true, "enabled": true}], "services": [ {"address": "1.1.1.1", "checks": [], "id": "test-service-1", "name": "test-service", "port": 20001, "tags": ["first"]}, {"address": "2.2.2.2", "checks": [], "id": "test-service-2", "name": "test-service", "port": 20002, "tags": ["second"]}, {"address": "3.3.3.3", "checks": [], "id": "test-service-3", "name": "test-service", "port": 20003, "tags": ["third"]} ]}'
     env:
       CONSUL_HTTP_ADDR: http://consul:8500
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -983,6 +983,19 @@ mod tests {
             .iter()
             .all(|item| addresses.contains(item)));
 
+        let tags: Vec<String> = response
+            .iter()
+            .map(|sn| sn.service.tags.clone().into_iter())
+            .flatten()
+            .collect();
+        let expected_tags = vec![
+            "first".to_string(),
+            "second".to_string(),
+            "third".to_string(),
+        ];
+        assert_eq!(expected_tags.len(), 3);
+        assert!(expected_tags.iter().all(|tag| tags.contains(tag)));
+
         let _: Vec<_> = response
             .iter()
             .map(|sn| assert_eq!("dc1", sn.node.datacenter))
@@ -1116,6 +1129,7 @@ mod tests {
             service: "node".to_string(),
             address: "2.2.2.2".to_string(),
             port: 32,
+            tags: vec!["foo".to_string(), "bar=baz".to_string()],
         };
 
         let empty_service = Service {
@@ -1123,6 +1137,7 @@ mod tests {
             service: "".to_string(),
             address: "".to_string(),
             port: 32,
+            tags: vec![],
         };
 
         let sn = ServiceNode {

--- a/src/types.rs
+++ b/src/types.rs
@@ -454,6 +454,8 @@ pub struct Service {
     pub address: String,
     /// The port of the instance.
     pub port: u16,
+    /// Tags assigned to the service instance.
+    pub tags: Vec<String>,
 }
 
 pub(crate) fn serialize_duration_as_string<S>(

--- a/testdata/config.hcl
+++ b/testdata/config.hcl
@@ -11,6 +11,7 @@ services {
   address = "1.1.1.1"
   port = 20001
   checks = []
+  tags = ["first"]
 }
 
 services {
@@ -19,6 +20,7 @@ services {
   address = "2.2.2.2"
   port = 20002
   checks = []
+  tags = ["second"]
 }
 
 services {
@@ -27,4 +29,5 @@ services {
   address = "3.3.3.3"
   port = 20003
   checks = []
+  tags = ["third"]
 }


### PR DESCRIPTION
# What problem are we solving?
`get_service_nodes` currently does not include a service's tags in the returned struct.
# How are we solving the problem?
Just deserialize the tags into a `Vec<String>`; the data is already present in the response.

# Checks
Please check these off before promoting the pull request to non-draft status.
- [ ] All CI checks are green.
- [ ] I have reviewed the proposed changes myself.
