### PR TITLE
Make client sync again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-## 0.8.0 - 2024-11-20
+## 0.8.1 - 2024-11-20
 
 ### Changed
 
 - `opentelemetry` upgraded to version `0.27` from `0.24`.
 - Removed `prometheus` dependency in the `metrics` feature, replacing it with a `metrics_receiver` in a metrics library agnostic fashion.
+
+## 0.8.0 - 2024-11-20
+
+- YANKED because `Consul` was no longer `Sync`.
 
 ## 0.7.0 - 2024-06-25
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs-consul"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Roblox"]
 edition = "2021"
 description = "This crate provides access to a set of strongly typed apis to interact with consul (https://www.consul.io/)"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,9 +228,9 @@ pub struct Consul {
     #[cfg(feature = "trace")]
     tracer: BoxedTracer,
     #[cfg(feature = "metrics")]
-    metrics_tx: std::sync::mpsc::Sender<MetricInfo>,
+    metrics_tx: tokio::sync::mpsc::UnboundedSender<MetricInfo>,
     #[cfg(feature = "metrics")]
-    metrics_rx: Option<std::sync::mpsc::Receiver<MetricInfo>>,
+    metrics_rx: Option<tokio::sync::mpsc::UnboundedReceiver<MetricInfo>>,
 }
 
 fn https_connector() -> hyper_rustls::HttpsConnector<HttpConnector> {
@@ -294,7 +294,7 @@ impl Consul {
     /// - [HttpsClient](consul::HttpsClient)
     pub fn new_with_client(config: Config, https_client: HttpsClient) -> Self {
         #[cfg(feature = "metrics")]
-        let (tx, rx) = std::sync::mpsc::channel::<MetricInfo>();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<MetricInfo>();
         Consul {
             https_client,
             config,
@@ -309,7 +309,7 @@ impl Consul {
 
     #[cfg(feature = "metrics")]
     /// Returns the metrics receiver for the consul client.
-    pub fn metrics_receiver(&mut self) -> Option<std::sync::mpsc::Receiver<MetricInfo>> {
+    pub fn metrics_receiver(&mut self) -> Option<tokio::sync::mpsc::UnboundedReceiver<MetricInfo>> {
         self.metrics_rx.take()
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -43,7 +43,7 @@ impl MetricInfo {
 #[derive(Debug, Clone)]
 pub(crate) struct MetricInfoWrapper {
     metrics: MetricInfo,
-    sender: Option<std::sync::mpsc::Sender<MetricInfo>>,
+    sender: Option<tokio::sync::mpsc::UnboundedSender<MetricInfo>>,
     start: std::time::Instant,
 }
 
@@ -53,7 +53,7 @@ impl MetricInfoWrapper {
         method: HttpMethod,
         function: Function,
         status: Option<StatusCode>,
-        sender: std::sync::mpsc::Sender<MetricInfo>,
+        sender: tokio::sync::mpsc::UnboundedSender<MetricInfo>,
     ) -> Self {
         Self {
             metrics: MetricInfo::new(method, function, status),


### PR DESCRIPTION
# What problem are we solving?
Consul was no longer sync because std's `Sender` not being `Sync`.
 
# How are we solving the problem?
Using tokio's mpsc primitives instead.

# Checks
Please check these off before promoting the pull request to non-draft status.
- [x] All CI checks are green.
- [x] I have reviewed the proposed changes myself.
