### PR TITLE
Fix metrics being emitted more than once.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+## 0.8.2 - 2024-11-22
+
+- Fix metrics being emitted more than once.
+
 ## 0.8.1 - 2024-11-20
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs-consul"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Roblox"]
 edition = "2021"
 description = "This crate provides access to a set of strongly typed apis to interact with consul (https://www.consul.io/)"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,7 +420,7 @@ impl Consul {
                 #[cfg(feature = "metrics")]
                 {
                     metrics_info_wrapper.set_status(code);
-                    drop(metrics_info_wrapper.clone());
+                    metrics_info_wrapper.emit_metrics();
                 }
                 ConsulError::UnexpectedResponseCode(
                     code,
@@ -438,7 +438,7 @@ impl Consul {
             #[cfg(feature = "metrics")]
             {
                 metrics_info_wrapper.set_status(StatusCode::OK);
-                drop(metrics_info_wrapper.clone());
+                metrics_info_wrapper.emit_metrics();
             }
             return Ok(response);
         }
@@ -822,7 +822,7 @@ impl Consul {
                     #[cfg(feature = "metrics")]
                     {
                         metrics_info_wrapper.set_status(StatusCode::REQUEST_TIMEOUT);
-                        drop(metrics_info_wrapper.clone());
+                        metrics_info_wrapper.emit_metrics();
                     }
                     Err(ConsulError::TimeoutExceeded(dur))
                 }
@@ -833,7 +833,7 @@ impl Consul {
 
         let response = response.inspect_err(|_| {
             #[cfg(feature = "metrics")]
-            drop(metrics_info_wrapper.clone());
+            metrics_info_wrapper.emit_metrics();
         })?;
 
         #[cfg(feature = "trace")]
@@ -844,7 +844,7 @@ impl Consul {
             #[cfg(feature = "metrics")]
             {
                 metrics_info_wrapper.set_status(status);
-                drop(metrics_info_wrapper);
+                metrics_info_wrapper.emit_metrics();
             }
 
             let mut response_body = response

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -65,7 +65,7 @@ impl MetricInfoWrapper {
     pub fn set_status(&mut self, status: StatusCode) {
         self.metrics.status = Some(status);
     }
-    
+
     pub fn emit_metrics(&mut self) {
         if let Some(sender) = self.sender.take() {
             let mut metrics = self.metrics;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -65,16 +65,20 @@ impl MetricInfoWrapper {
     pub fn set_status(&mut self, status: StatusCode) {
         self.metrics.status = Some(status);
     }
+    
+    pub fn emit_metrics(&mut self) {
+        if let Some(sender) = self.sender.take() {
+            let mut metrics = self.metrics;
+            metrics.duration = Some(self.start.elapsed());
+            let _ = sender.send(metrics);
+        }
+    }
 }
 
 #[cfg(feature = "metrics")]
 impl Drop for MetricInfoWrapper {
     fn drop(&mut self) {
-        if let Some(sender) = self.sender.take() {
-            let mut metrics = self.metrics;
-            metrics.duration = Some(self.start.elapsed());
-            let _ = sender.send(self.metrics);
-        }
+        self.emit_metrics();
     }
 }
 


### PR DESCRIPTION
# What problem are we solving?
Metrics are emitted twice because the clone happens before the `take` on the sender.

# How are we solving the problem?
Removing the clone. 

# Checks
Please check these off before promoting the pull request to non-draft status.
- [x] All CI checks are green.
- [x] I have reviewed the proposed changes myself.
