### PR TITLE
fix(trace): align span status per OpenTelemetry specs

### DIFF
--- a/src/hyper_wrapper.rs
+++ b/src/hyper_wrapper.rs
@@ -82,7 +82,9 @@ pub fn annotate_span_for_response<T>(span: &mut BoxedSpan, response: &hyper::Res
         ));
     }
 
-    if status != hyper::StatusCode::OK {
+    // Mark server errors (5xx) and client errors (4xx) as span errors per OpenTelemetry specs
+    // See: https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
+    if status.is_client_error() || status.is_server_error() {
         span.set_status(Status::error(status.as_str().to_owned()));
     }
 }


### PR DESCRIPTION
# What problem are we solving?

Previously, any non-200 HTTP response would set the span status to error in `hyper_wrapper.rs`. According to OpenTelemetry specs, this should only happen on client errors (4xx) and server errors (5xx).

# How are we solving the problem?

Aligning the implementation to match OpenTelemetry spec: https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status

# Checks
Please check these off before promoting the pull request to non-draft status.
- [x] All CI checks are green.
- [x] I have reviewed the proposed changes myself.
