### PR TITLE
Support registering multiple health checks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+## 0.10.0 - 2025-05-13
+- Supports registering multiple health checks. This breaks backward compatibility and drops supports to consul servers
+older than 0.5.0 that do not have this commit: [674be58e55f](https://github.com/hashicorp/consul/commit/674be58e55f3f2b1f1c64ef2f52bfbd577db0c7c)
+
 ## 0.9.0 - 2025-02-12
 
 - Upgrade `opentelemetry` to `0.28` from `0.27`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rs-consul"
 # Don't forget to update the readme with the new version!
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Roblox"]
 edition = "2021"
 description = "This crate provides access to a set of strongly typed apis to interact with consul (https://www.consul.io/)"

--- a/examples/register_service.rs
+++ b/examples/register_service.rs
@@ -27,7 +27,7 @@ async fn main() {
             Port: Some(42424),
             Namespace: None,
         }),
-        Check: None,
+        Checks: Vec::new(),
         SkipNodeUpdate: None,
     };
     consul.register_entity(&payload).await.unwrap();

--- a/src/types.rs
+++ b/src/types.rs
@@ -312,9 +312,8 @@ pub struct RegisterEntityPayload {
     /// Optional service to register.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub Service: Option<RegisterEntityService>,
-    /// Optional check to register
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub Check: Option<RegisterEntityCheck>,
+    /// Checks to register.
+    pub Checks: Vec<RegisterEntityCheck>,
     /// Whether to skip updating the nodes information in the registration.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub SkipNodeUpdate: Option<bool>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -313,6 +313,7 @@ pub struct RegisterEntityPayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub Service: Option<RegisterEntityService>,
     /// Checks to register.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub Checks: Vec<RegisterEntityCheck>,
     /// Whether to skip updating the nodes information in the registration.
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
# What problem are we solving?
Today, the RegisterEntityPayload offers the legacy registration interface that allowed registering a single `Check`. Consul supports registering multiple health checks starting in 2015 (commit 674be58e55f). For backward compatibility they maintain support for passing a single `Check`.  Here is the relevant excerpt from agent/consul/catalog_endpoint.go:
```
// Move the old format single check into the slice, and fixup IDs.
if args.Check != nil {
        args.Checks = append(args.Checks, args.Check)
        args.Check = nil
}
```

# How are we solving the problem?
Let's switch from offering a single 'Check' to running multiple 'Checks'. This breaks backwards compatibility and drops support to consuls servers from 10 years ago.

# Checks
Please check these off before promoting the pull request to non-draft status.
- [ ] All CI checks are green.
- [ ] I have reviewed the proposed changes myself.
